### PR TITLE
Add 'tweet' object key

### DIFF
--- a/delete.py
+++ b/delete.py
@@ -58,7 +58,7 @@ class TwitterDelete:
             tweet_history = json.loads(tweets)
 
             for row in tweet_history:
-                tweet_ids.append(row.get("id"))
+                tweet_ids.append(row["tweet"].get("id"))
 
         try:
             with open(deleted_csvs, "r") as deleteds_file:


### PR DESCRIPTION
Without this change, running `pipenv run python delete.py` results in a lot of:

```
Twitter API returned a 404 (Not Found), Sorry, that page does not exist
Twitter API returned a 404 (Not Found), Sorry, that page does not exist
Twitter API returned a 404 (Not Found), Sorry, that page does not exist
Twitter API returned a 404 (Not Found), Sorry, that page does not exist
Twitter API returned a 404 (Not Found), Sorry, that page does not exist
```

Based on my very quick investigation, Twitter might have changed the format late last year or early this year.